### PR TITLE
parse sparse info correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,14 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "node"
+env:
+  global:
+    - REPO_OWNER=vokal
+    - REPO_NAME=cobertura-parse
+install:
+  - npm install -g istanbul
+  - npm install
+script:
+  - chmod +x run-build.sh
+  - ./run-build.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cobertura-parse",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Parse cobertura coverage to JSON, based on output from lcov-parse",
   "main": "source/index.js",
   "scripts": {

--- a/run-build.sh
+++ b/run-build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+npm run testcover
+
+RESULT=$?
+
+COMMIT="${TRAVIS_COMMIT_RANGE##*...}"
+
+if [ $RESULT == 0 ]; then
+  echo "publish coverage for $COMMIT"
+  curl -F coverage=@coverage/lcov.info "https://cvr.vokal.io/coverage?owner=$REPO_OWNER&repo=$REPO_NAME&commit=$COMMIT&coveragetype=lcov"
+else
+  curl -X POST "https://cvr.vokal.io/coverage/abort?owner=$REPO_OWNER&repo=$REPO_NAME&commit=$COMMIT"
+fi
+
+exit $RESULT

--- a/source/index.js
+++ b/source/index.js
@@ -33,9 +33,9 @@ var unpackage = function ( packages )
             title: c.$.name,
             file: c.$.filename,
             functions: {
-                found: c.methods[ 0 ].method ? c.methods[ 0 ].method.length : 0,
+                found: c.methods && c.methods[ 0 ].method ? c.methods[ 0 ].method.length : 0,
                 hit: 0,
-                details: !c.methods[ 0 ].method ? [] : c.methods[ 0 ].method.map( function ( m )
+                details: !c.methods || !c.methods[ 0 ].method ? [] : c.methods[ 0 ].method.map( function ( m )
                 {
                     return {
                         name: m.$.name,
@@ -45,9 +45,9 @@ var unpackage = function ( packages )
                 } )
             },
             lines: {
-                found: c.lines[ 0 ].line ? c.lines[ 0 ].line.length : 0,
+                found: c.lines && c.lines[ 0 ].line ? c.lines[ 0 ].line.length : 0,
                 hit: 0,
-                details: !c.lines[ 0 ].line ? [] : c.lines[ 0 ].line.map( function ( l )
+                details: !c.lines || !c.lines[ 0 ].line ? [] : c.lines[ 0 ].line.map( function ( l )
                 {
                     return {
                         line: Number( l.$.number ),

--- a/test/assets/sample2.xml
+++ b/test/assets/sample2.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
 <coverage>
   <sources>
-    <source>/Users/bboland/src/vokal/Brandish-iOS</source>
+    <source>ios</source>
   </sources>
   <packages>
     <package name="Headers">

--- a/test/assets/sample2.xml
+++ b/test/assets/sample2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage>
+  <sources>
+    <source>/Users/bboland/src/vokal/Brandish-iOS</source>
+  </sources>
+  <packages>
+    <package name="Headers">
+      <classes>
+        <class filename="NSException.h" name="NSException.h">
+          <methods />
+          <lines>
+            <line branch="false" hits="0" number="102" />
+            <line branch="false" hits="0" number="103" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="Headers2">
+      <classes>
+        <class filename="NSException.h" name="NSException.h" />
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/test/index.js
+++ b/test/index.js
@@ -24,4 +24,20 @@ describe( "parseFile", function ()
             done();
         } );
     } );
+
+    it( "should parse a sparse file", function ( done )
+    {
+        parse.parseFile( path.join( __dirname, "assets", "sample2.xml" ), function ( err, result )
+        {
+            assert.equal( err, null );
+            assert.equal( result.length, 2 );
+            assert.equal( result[ 0 ].functions.found, 0 );
+            assert.equal( result[ 0 ].functions.hit, 0 );
+            assert.equal( result[ 0 ].lines.found, 2 );
+            assert.equal( result[ 0 ].lines.hit, 0 );
+            assert.equal( result[ 0 ].functions.details.length, 0 );
+            assert.equal( result[ 0 ].lines.details.length, 2 );
+            done();
+        } );
+    } );
 } );


### PR DESCRIPTION
the `<methods/>` and `<lines/>` elements don't necessarily appear in the coverage info, so this acts appropriately in their absence.

@brockboland 
